### PR TITLE
Ability to configure Mincer dynamically added (`configure: (mincer) -> ...`)

### DIFF
--- a/tasks/lib/mince.js
+++ b/tasks/lib/mince.js
@@ -14,13 +14,15 @@ exports.init = function(grunt) {
 
   var exports = {};
 
-  exports.mince = function(src, dest, include, fn) {
+  exports.mince = function(src, dest, include, configurator, fn) {
     var environment = new Mincer.Environment(process.cwd()),
       asset;
 
     include.forEach(function(include) {
       environment.appendPath(include);
     });
+
+    if (configurator) { configurator(Mincer); }
 
     asset = environment.findAsset(src);
     if (!asset) {

--- a/tasks/mincer.js
+++ b/tasks/mincer.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
       done = this.async();
 
     grunt.log.write('Generating file ' + dest.cyan + '...');
-    mince(src, dest, include, function(err) {
+    mince(src, dest, include, options.configure, function(err) {
       if (err) {
         grunt.warn(err);
       } else {


### PR DESCRIPTION
Required i.e. to add support of `nib` to Stylus. Example:

``` coffee
    mince:
      styles:
        include: ['stylesheets', 'public']
        src: 'application.styl'
        dest: 'public/assets/application.css'
        configure: (mincer) ->
          mincer.StylusEngine.registerConfigurator (stylus) ->
            stylus.use require('nib')()
```
