### PR TITLE
Keep subdirectory structure when compiling a manifest file [Fixes #14, #17]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
           include: ['test/fixtures', 'test/fixtures/lib'],
         },
         files: [{
-          src: 'test/fixtures/main.js',
+          src: ['test/fixtures/main.js', 'test/fixtures/lib/external.js'],
           dest: 'tmp/mainfest.js'
         }]
       },

--- a/tasks/lib/helpers.js
+++ b/tasks/lib/helpers.js
@@ -19,9 +19,21 @@ exports.init = function (grunt) {
   };
 
   var logicalAssetName = function(environment, filename) {
-    var engines = environment.getEngines();
+    var engines = environment.getEngines(),
+      resolvedFilename = path.resolve(filename),
+      _path, _i, _len;
 
-    var parts = path.basename(filename).split('.');
+    for (_i = 0, _len = environment.paths.length; _i < _len; _i++) {
+      _path = environment.paths[_i];
+      if(_path.slice(-1, 1) !== '/') {
+        _path += '/';
+      }
+      if(resolvedFilename.slice(0, _path.length) === _path) {
+        resolvedFilename = resolvedFilename.slice(_path.length);
+        break;
+      }
+    }
+    var parts = resolvedFilename.split('.');
     while(engines.hasOwnProperty('.' + parts.slice(-1)[0])) {
       parts.pop();
     }
@@ -53,7 +65,6 @@ exports.init = function (grunt) {
     [].concat(options.include).forEach(function (include) {
       environment.appendPath(include);
     });
-    environment.appendPath(path.dirname(src));
 
     Object.keys(options.helpers).forEach(function (key) {
       // Create a bound function which has access to the current Mincer.Environment
@@ -91,19 +102,13 @@ exports.init = function (grunt) {
   };
 
   exports.compileManifest = function(files, options) {
-    var inputFiles = [],
-      includePaths = options.include;
+    var inputFiles = [];
 
     files.forEach(function(file) {
       inputFiles = inputFiles.concat(file.src.map(function(filepath) {
-        return path.basename(filepath);
-      }));
-      includePaths = includePaths.concat(file.src.map(function(filepath) {
-        return path.dirname(filepath);
+        return filepath;
       }));
     });
-
-    options.include = includePaths.filter(arrayUnique);
 
     if (options.banner) {
       grunt.log.warn('Banner option is not supported when compiling to manifest.');

--- a/test/mincer_test.js
+++ b/test/mincer_test.js
@@ -1,3 +1,4 @@
+'use strict';
 var grunt = require('grunt');
 
 exports.mince = {
@@ -18,12 +19,13 @@ exports.mince = {
   },
 
   'mince manifest': function(test) {
-    test.expect(3);
+    test.expect(4);
 
     var manifest = grunt.file.readJSON('tmp/manifest/manifest.json');
     test.ok(manifest.assets, 'manifest is valid');
     test.ok(manifest.files, 'manifest is valid');
     test.equal(manifest.assets['main.js'].indexOf('main-'), 0, 'generated asset name starts with original asset name');
+    test.equal(manifest.assets['lib/external.js'].indexOf('lib/external-'), 0, 'subdirectory structure is honored in manifest');
 
     test.done();
   },


### PR DESCRIPTION
Keep the subdirectory information for assets when writing a manifest
file. The logical path in the manifest now represents the original
location in the filesystem and the fingerprinted asset will reflect
the original directory structure.

See bug reports #14, #17 for details.
