### PR TITLE
fix(windows): Fixes path seperator on windows.

### DIFF
--- a/tasks/lib/helpers.js
+++ b/tasks/lib/helpers.js
@@ -27,8 +27,8 @@ exports.init = function (grunt) {
 
     for (_i = 0, _len = environment.paths.length; _i < _len; _i++) {
       _path = environment.paths[_i];
-      if(_path.slice(-1, 1) !== '/') {
-        _path += '/';
+      if(_path.slice(-1, 1) !== path.sep) {
+        _path += path.sep;
       }
       if(resolvedFilename.slice(0, _path.length) === _path) {
         resolvedFilename = resolvedFilename.slice(_path.length);

--- a/tasks/mincer.js
+++ b/tasks/mincer.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
         embedMappingComments: true
       },
       sourceMappingBaseURL: '',
-      sourceMappingURL: function (options, file) { return options.sourceMappingBaseURL + file.dest + '.map' },
+      sourceMappingURL: function (options, file) { return options.sourceMappingBaseURL + file.dest + '.map'; },
       helpers: {},
       engines: {},
       jsCompressor: null,


### PR DESCRIPTION
Theres a bug on windows whereby expanding a path defined like `/test.css.styl` will expand to `/test.css` and the styl file won't be found. This is due to the hardcoding of the path separator.
Also fixed a missing semicolon that was failing jslint.

Originally opened an issue in mincer repo until I looked into it a bit more. https://github.com/nodeca/mincer/issues/165
